### PR TITLE
Fix the back button for the thread catalog on phones

### DIFF
--- a/app/src/main/java/com/luorrak/ouroboros/catalog/BoardListFragment.java
+++ b/app/src/main/java/com/luorrak/ouroboros/catalog/BoardListFragment.java
@@ -56,6 +56,7 @@ import com.luorrak.ouroboros.util.InfiniteDbHelper;
 public class BoardListFragment extends Fragment implements OnStartDragListener {
     private NavigationBoardListAdapter boardListAdapter;
     private ItemTouchHelper touchHelper;
+    private InfiniteDbHelper infiniteDbHelper;
 
     public BoardListFragment() {
     }
@@ -67,7 +68,13 @@ public class BoardListFragment extends Fragment implements OnStartDragListener {
         getActivity().setTitle("Boards");
         View view = inflater.inflate(R.layout.fragment_board_list, container, false);
 
-        InfiniteDbHelper infiniteDbHelper = new InfiniteDbHelper(getActivity());
+        if (infiniteDbHelper != null) {
+            // Clear any previous incarnations of the database helper
+            // to prevent the database from remaining locked.
+            infiniteDbHelper.close();
+        }
+
+        infiniteDbHelper = new InfiniteDbHelper(getActivity());
         Cursor boardListCursor = infiniteDbHelper.getBoardCursor();
 
         RecyclerView recyclerView = (RecyclerView) view.findViewById(R.id.board_list);

--- a/app/src/main/java/com/luorrak/ouroboros/catalog/CatalogActivity.java
+++ b/app/src/main/java/com/luorrak/ouroboros/catalog/CatalogActivity.java
@@ -3,6 +3,7 @@ package com.luorrak.ouroboros.catalog;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.design.widget.NavigationView;
+import android.support.v4.app.FragmentManager;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.app.AppCompatActivity;
@@ -189,7 +190,20 @@ public class CatalogActivity extends AppCompatActivity implements NavigationView
     public void launchBoardFragment(String board){
         this.board = board; //The real reason for this method being here
         CatalogFragment catalogFragment = new CatalogFragment().newInstance(board);
-        android.support.v4.app.FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
-        fragmentTransaction.replace(R.id.activity_catalog_fragment_container, catalogFragment).commit();
+
+
+        final FragmentManager fragmentManager = getSupportFragmentManager();
+        android.support.v4.app.FragmentTransaction fragmentTransaction =
+            fragmentManager.beginTransaction();
+        fragmentTransaction
+            .replace(
+                R.id.activity_catalog_fragment_container,
+                catalogFragment
+            )
+            .addToBackStack("Back To Board Catalog")
+            .commit();
+        // This call is required to prevent app crashes
+        // when quickly pushing and popping the fragment stack.
+        fragmentManager.executePendingTransactions();
     }
 }


### PR DESCRIPTION
In the current version of this app on the Google Play store, pressing the back button from the thread catalog will hide the application. I found this very annoying, so I wrote a patch to make the back button go back to the board list, instead of closing the application. I had to close, cancel, clear, or otherwise handle null references for several objects to prevent the application from crashing in stupid ways in the process. It seems to pretty much work.