### PR TITLE
Fix problems with loading images and thumbnails due to URL changes.

### DIFF
--- a/app/src/main/java/com/luorrak/ouroboros/catalog/CatalogAdapter.java
+++ b/app/src/main/java/com/luorrak/ouroboros/catalog/CatalogAdapter.java
@@ -79,7 +79,11 @@ public class CatalogAdapter extends CursorRecyclerAdapter implements Filterable 
         }
 
         if (catalogViewHolder.catalogObject.tim != null){
-            imageUrl = ChanUrls.getThumbnailUrl(boardName, catalogViewHolder.catalogObject.tim);
+            imageUrl = ChanUrls.getThumbnailUrl(
+                boardName,
+                catalogViewHolder.catalogObject.tim,
+                catalogViewHolder.catalogObject.ext
+            );
             networkHelper.getImageNoCrossfade(catalogViewHolder.catalogPicture, imageUrl);
         } else if (catalogViewHolder.catalogObject.embed != null) {
             youtubeData = Util.parseYoutube(catalogViewHolder.catalogObject.embed);
@@ -131,6 +135,7 @@ public class CatalogAdapter extends CursorRecyclerAdapter implements Filterable 
         catalogViewHolder.catalogObject.sub = cursor.getString(cursor.getColumnIndex(DbContract.CatalogEntry.COLUMN_CATALOG_SUB));
         catalogViewHolder.catalogObject.com = cursor.getString(cursor.getColumnIndex(DbContract.CatalogEntry.COLUMN_CATALOG_COM));
         catalogViewHolder.catalogObject.tim = cursor.getString(cursor.getColumnIndex(DbContract.CatalogEntry.COLUMN_CATALOG_TIM));
+        catalogViewHolder.catalogObject.ext = cursor.getString(cursor.getColumnIndex(DbContract.CatalogEntry.COLUMN_CATALOG_EXT));
         catalogViewHolder.catalogObject.replyCount = String.valueOf(cursor.getInt(cursor.getColumnIndex(DbContract.CatalogEntry.COLUMN_CATALOG_REPLIES)));
         catalogViewHolder.catalogObject.imageReplyCount = String.valueOf(cursor.getInt(cursor.getColumnIndex(DbContract.CatalogEntry.COLUMN_CATALOG_IMAGES)));
         catalogViewHolder.catalogObject.locked = cursor.getInt(cursor.getColumnIndex(DbContract.CatalogEntry.COLUMN_CATALOG_LOCKED));
@@ -198,12 +203,12 @@ public class CatalogAdapter extends CursorRecyclerAdapter implements Filterable 
         String sub;
         String com;
         String tim;
+        String ext;
         String replyCount;
         String imageReplyCount;
         int locked;
         int sticky;
         String embed;
         int itemViewType;
-
     }
 }

--- a/app/src/main/java/com/luorrak/ouroboros/catalog/WatchListAdapter.java
+++ b/app/src/main/java/com/luorrak/ouroboros/catalog/WatchListAdapter.java
@@ -64,8 +64,15 @@ public class WatchListAdapter extends CursorRecyclerAdapter implements TouchHelp
 
         if (watchlistViewHolder.watchlistObject.serializedMediaList != null){
             ArrayList<Media> deserializedMediaList = (ArrayList<Media>) Util.deserializeObject(watchlistViewHolder.watchlistObject.serializedMediaList);
+
+            final Media media = deserializedMediaList.get(0);
+
             Ion.with(watchlistViewHolder.watchlistThumbnail)
-                    .load(ChanUrls.getThumbnailUrl(watchlistViewHolder.watchlistObject.board, deserializedMediaList.get(0).fileName))
+                    .load(ChanUrls.getThumbnailUrl(
+                        watchlistViewHolder.watchlistObject.board,
+                        media.fileName,
+                        media.ext
+                    ))
                     .withBitmapInfo();
         }
     }

--- a/app/src/main/java/com/luorrak/ouroboros/deepzoom/DeepZoomFragment.java
+++ b/app/src/main/java/com/luorrak/ouroboros/deepzoom/DeepZoomFragment.java
@@ -11,7 +11,6 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.ActionProvider;
 import android.support.v4.view.MenuItemCompat;
-import android.support.v7.graphics.Palette;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -108,7 +107,11 @@ public class DeepZoomFragment extends Fragment{
         progressBar.setVisibility(View.VISIBLE);
 
         Ion.with(photoView)
-                .load(ChanUrls.getThumbnailUrl(boardName, mediaItem.fileName))
+                .load(ChanUrls.getThumbnailUrl(
+                    boardName,
+                    mediaItem.fileName,
+                    mediaItem.ext
+                ))
                 .withBitmapInfo()
                 .setCallback(new FutureCallback<ImageViewBitmapInfo>() {
                     @Override
@@ -128,7 +131,11 @@ public class DeepZoomFragment extends Fragment{
                         Ion.with(photoView)
                                 .crossfade(true)
                                 .deepZoom()
-                                .load(ChanUrls.getImageUrl(boardName, mediaItem.fileName, mediaItem.ext))
+                                .load(ChanUrls.getImageUrl(
+                                    boardName,
+                                    mediaItem.fileName,
+                                    mediaItem.ext
+                                ))
                                 .withBitmapInfo();
                     }
                 });
@@ -143,7 +150,11 @@ public class DeepZoomFragment extends Fragment{
             mediaPlayButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    Uri uri = Uri.parse(ChanUrls.getImageUrl(boardName, mediaItem.fileName, mediaItem.ext));
+                    final Uri uri = Uri.parse(ChanUrls.getImageUrl(
+                        boardName,
+                        mediaItem.fileName,
+                        mediaItem.ext
+                    ));
                     Intent intent = new Intent(Intent.ACTION_VIEW, uri);
                     intent.setDataAndType(uri, "video/" + mediaItem.ext.substring(1));
                     startActivity(intent);
@@ -189,14 +200,23 @@ public class DeepZoomFragment extends Fragment{
                 break;
             }
             case R.id.action_external_browser: {
-                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(ChanUrls.getImageUrl(boardName, mediaItem.fileName, mediaItem.ext)));
+                final Uri uri = Uri.parse(ChanUrls.getImageUrl(
+                    boardName,
+                    mediaItem.fileName,
+                    mediaItem.ext
+                ));
+                Intent browserIntent = new Intent(Intent.ACTION_VIEW, uri);
                 startActivity(browserIntent);
                 break;
             }
             case R.id.menu_item_share: {
                 Intent shareIntent = new Intent(Intent.ACTION_SEND);
                 shareIntent.setType("text/plain");
-                String shareBody = ChanUrls.getImageUrl(boardName, mediaItem.fileName, mediaItem.ext);
+                String shareBody = ChanUrls.getImageUrl(
+                    boardName,
+                    mediaItem.fileName,
+                    mediaItem.ext
+                );
                 shareIntent.putExtra(Intent.EXTRA_TEXT, shareBody);
                 startActivity(Intent.createChooser(shareIntent, "Share via"));
                 break;

--- a/app/src/main/java/com/luorrak/ouroboros/gallery/GalleryAdapter.java
+++ b/app/src/main/java/com/luorrak/ouroboros/gallery/GalleryAdapter.java
@@ -14,7 +14,6 @@ import com.luorrak.ouroboros.R;
 import com.luorrak.ouroboros.deepzoom.DeepZoomActivity;
 import com.luorrak.ouroboros.util.ChanUrls;
 import com.luorrak.ouroboros.util.Media;
-import com.luorrak.ouroboros.util.NetworkHelper;
 import com.luorrak.ouroboros.util.Util;
 
 import java.util.ArrayList;
@@ -66,7 +65,11 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.GalleryV
         resetView(galleryViewHolder);
 
         Ion.with(galleryViewHolder.galleryImage)
-                .load(ChanUrls.getThumbnailUrl(boardName, media.fileName))
+                .load(ChanUrls.getThumbnailUrl(
+                    boardName,
+                    media.fileName,
+                    media.ext
+                ))
                 .withBitmapInfo();
 
         if (validExt.contains(media.ext)){

--- a/app/src/main/java/com/luorrak/ouroboros/thread/MediaAdapter.java
+++ b/app/src/main/java/com/luorrak/ouroboros/thread/MediaAdapter.java
@@ -132,7 +132,11 @@ public class MediaAdapter extends RecyclerView.Adapter<MediaAdapter.MediaViewHol
         }
 
         if (validExt.contains(media.ext)){
-            String imageUrl = ChanUrls.getThumbnailUrl(boardName, media.fileName);
+            String imageUrl = ChanUrls.getThumbnailUrl(
+                boardName,
+                media.fileName,
+                media.ext
+            );
             if (SettingsHelper.getImageOptions(context) != 3){
                 Ion.with(mediaViewHolder.mediaImage)
                         .smartSize(true)
@@ -153,13 +157,21 @@ public class MediaAdapter extends RecyclerView.Adapter<MediaAdapter.MediaViewHol
                                     Ion.with(result.getImageView())
                                             .crossfade(true)
                                             .smartSize(true)
-                                            .load(ChanUrls.getImageUrl(boardName, media.fileName, media.ext))
+                                            .load(ChanUrls.getImageUrl(
+                                                boardName,
+                                                media.fileName,
+                                                media.ext
+                                            ))
                                             .withBitmapInfo();
                                 } else if (SettingsHelper.getImageOptions(context) == 0){
                                     Ion.with(result.getImageView())
                                             .crossfade(true)
                                             .smartSize(true)
-                                            .load(ChanUrls.getImageUrl(boardName, media.fileName, media.ext))
+                                            .load(ChanUrls.getImageUrl(
+                                                boardName,
+                                                media.fileName,
+                                                media.ext
+                                            ))
                                             .withBitmapInfo();
                                 }
 
@@ -180,7 +192,12 @@ public class MediaAdapter extends RecyclerView.Adapter<MediaAdapter.MediaViewHol
                 }
             });
         } else if (media.ext.equals(".webm") || media.ext.equals(".mp4")){
-            String imageUrl = ChanUrls.getThumbnailUrl(boardName, media.fileName);
+            String imageUrl = ChanUrls.getThumbnailUrl(
+                boardName,
+                media.fileName,
+                media.ext
+            );
+
             Ion.with(mediaViewHolder.mediaImage)
                     .smartSize(true)
                     .crossfade(true)
@@ -202,7 +219,11 @@ public class MediaAdapter extends RecyclerView.Adapter<MediaAdapter.MediaViewHol
                 mediaViewHolder.playButton.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        Uri uri = Uri.parse(ChanUrls.getImageUrl(boardName, media.fileName, media.ext));
+                        Uri uri = Uri.parse(ChanUrls.getImageUrl(
+                            boardName,
+                            media.fileName,
+                            media.ext
+                        ));
                         Intent intent = new Intent(Intent.ACTION_VIEW);
                         intent.setDataAndType(uri, "video/webm");
                         mediaViewHolder.itemView.getContext().startActivity(intent);
@@ -212,7 +233,11 @@ public class MediaAdapter extends RecyclerView.Adapter<MediaAdapter.MediaViewHol
                 mediaViewHolder.playButton.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        Uri uri = Uri.parse(ChanUrls.getImageUrl(boardName, media.fileName, media.ext));
+                        Uri uri = Uri.parse(ChanUrls.getImageUrl(
+                            boardName,
+                            media.fileName,
+                            media.ext
+                        ));
                         Intent intent = new Intent(Intent.ACTION_VIEW);
                         intent.setDataAndType(uri, "video/mp4");
                         mediaViewHolder.itemView.getContext().startActivity(intent);

--- a/app/src/main/java/com/luorrak/ouroboros/util/ChanUrls.java
+++ b/app/src/main/java/com/luorrak/ouroboros/util/ChanUrls.java
@@ -27,10 +27,28 @@ public class ChanUrls {
     private static final String CATALOG_ENDPOINT = "catalog.json"; //http(s)://siteurl/board/catalog.json
     private static final String THREAD_FOLDER = "res"; //http(s):///siteurl/board/res/threadnumber.json
     private static final String THREAD_ENDPOINT = ".json";
-    private static final String IMAGE_THUMBNAIL_DIRECTORY = "thumb";
-    private static final String IMAGE_DIRECTORY = "src"; //http(s)://siteurl/board/src/tim.ext
+    private static final String OLD_IMAGE_THUMBNAIL_DIRECTORY = "thumb";
+    private static final String IMAGE_THUMBNAIL_DIRECTORY = "file_store/thumb";
+    private static final String OLD_IMAGE_DIRECTORY = "src";
+    private static final String IMAGE_DIRECTORY = "file_store"; //http(s)://siteurl/file_store/tim.ext
     private static final String POST_ENDPOINT = "post.php";
     private static final String DNSBL_ENDPOINT = "dnsbls_bypass.php"; //https://8ch.net/dnsbls_bypass.php
+    private static final int OLD_TIM_MAX_LENGTH = 16;
+
+    /**
+     * Determine if the file uses an older 8chan URL.
+     * There are some files on the site still in existence which must be
+     * supported in this manner.
+     *
+     * @param tim The filename part before the extension.
+     * @return Return true if this a file with an old URL.
+     */
+    private static boolean isOldTim(String tim) {
+        // The current filename scheme uses much larger filenames,
+        // so we can just check the length of this string to detect whether
+        // or not we should use the old path or the new path.
+        return tim.length() <= OLD_TIM_MAX_LENGTH;
+    }
 
     public static String getCatalogUrl(String boardName){
         Uri.Builder builder = new Uri.Builder();
@@ -73,25 +91,60 @@ public class ChanUrls {
         return builder.toString();
     }
 
-    public static String getThumbnailUrl(String boardName, String tim){
+    public static String getThumbnailUrl(String boardName, String tim, String ext){
         Uri.Builder builder = new Uri.Builder();
-        builder.scheme(SCHEME)
+
+        if (
+            !ext.equals(".jpg")
+            && !ext.equals(".jpeg")
+            && !ext.equals(".png")
+            && !ext.equals(".gif")
+        ) {
+            // Only some files retain the same extension.
+            // Otherwise, the thumbnails are JPEGs.
+            ext = ".jpg";
+        }
+
+        if (isOldTim(tim)) {
+            // Some older files use an old path including the board name.
+            // The old images always use JPEG thumbnails, apart from some
+            // special board images we will just ignore.
+            builder.scheme(SCHEME)
                 .authority(DOMAIN_NAME)
                 .appendPath(boardName)
-                .appendPath(IMAGE_THUMBNAIL_DIRECTORY)
+                .appendPath(OLD_IMAGE_THUMBNAIL_DIRECTORY)
                 .appendPath(tim + ".jpg")
                 .build();
+        } else {
+            builder.scheme(SCHEME)
+                .authority(DOMAIN_NAME)
+                .appendPath(IMAGE_THUMBNAIL_DIRECTORY)
+                .appendPath(tim + ext)
+                .build();
+        }
+
         return builder.toString();
     }
 
     public static String getImageUrl(String boardName, String tim, String ext){
         Uri.Builder builder = new Uri.Builder();
-        builder.scheme(SCHEME)
+
+        if (isOldTim(tim)) {
+            // Some older files use an old path including the board name.
+            builder.scheme(SCHEME)
                 .authority(DOMAIN_NAME)
                 .appendPath(boardName)
+                .appendPath(OLD_IMAGE_DIRECTORY)
+                .appendPath(tim + ext)
+                .build();
+        } else {
+            builder.scheme(SCHEME)
+                .authority(DOMAIN_NAME)
                 .appendPath(IMAGE_DIRECTORY)
                 .appendPath(tim + ext)
                 .build();
+        }
+
         return builder.toString();
     }
 

--- a/app/src/main/java/com/luorrak/ouroboros/util/NetworkHelper.java
+++ b/app/src/main/java/com/luorrak/ouroboros/util/NetworkHelper.java
@@ -253,7 +253,8 @@ public class NetworkHelper {
     }
 
     public void downloadFile(String boardName, String tim, String ext, Context context){
-        DownloadManager.Request request = new DownloadManager.Request(Uri.parse(ChanUrls.getImageUrl(boardName, tim, ext)));
+        Uri uri = Uri.parse(ChanUrls.getImageUrl(boardName, tim, ext));
+        DownloadManager.Request request = new DownloadManager.Request(uri);
         request.setDescription(tim + ext);
         request.setTitle(tim + ext);
         request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS + "/Ouroboros", tim + ext);


### PR DESCRIPTION
As promised, I had a go at fixing the image loading issues. 8chan changed its URLs for images. The board name is now no longer in the path. Image files are at `/file_store/` and thumbnails are at `/file_store/thumb/`. However, any existing files are still being served from their old URLs. Because of this, I had to add in a filename hack which checks if the filename looks kind of like an old filename, and then switches to the old URL format, which the app will have to do for a while.

The image URLs still aren't perfect. There is one file which uses the old path, but has a PNG thumbnail for some reason, stickied on the `/pol/` board. I think we can probably just ignore this issue, as it will go away as soon as the thread is deleted, and people start uploading new files. The new URLs retain the same file extension for thumbnails for some images, which you can see in the code.